### PR TITLE
Fix bogus 'short address not allowed' errors

### DIFF
--- a/Makefile.def-samples/Makefile.def-emscripten
+++ b/Makefile.def-samples/Makefile.def-emscripten
@@ -2,23 +2,27 @@
 # choose your compiler (must be ANSI-compliant!) and linker command, plus
 # any additionally needed flags
 
+# ...for host-side build tools:
+
 OBJDIR =
-CC = emcc
-CFLAGS = -g -O3 -fomit-frame-pointer -Wall
+CC = gcc
+CFLAGS = -g -O3 -fomit-frame-pointer -Wall -Wextra -Werror -Wstrict-prototypes
+#CFLAGS = $(CFLAGS) -ansi -std=c89 -pedantic
 HOST_OBJEXTENSION = .o
+LDFLAGS =
 LD = $(CC)
-LDFLAGS =  -lnodefs.js -lnoderawfs.js
 HOST_EXEXTENSION =
 
-# no cross build
+# ...for the actual build target.
 
-TARG_OBJDIR = $(OBJDIR)
-TARG_CC = $(CC)
-TARG_CFLAGS = $(CFLAGS)
-TARG_OBJEXTENSION = $(HOST_OBJEXTENSION)
-TARG_LD = $(LD)
-TARG_LDFLAGS = $(LDFLAGS)
-TARG_EXEXTENSION = $(HOST_EXEXTENSION)
+TARG_OBJDIR = wasm-emscripten/
+TARG_CC = emcc
+TARG_CFLAGS = -g -O3 -fomit-frame-pointer -Wall
+TARG_OBJEXTENSION = .o
+TARG_LD = $(TARG_CC)
+TARG_LDFLAGS = -lnodefs.js -lnoderawfs.js
+TARG_EXEXTENSION = .wasm
+TARG_RUNCMD = node
 
 # -------------------------------------------------------------------------
 # directories where binaries, includes, and manpages should go during
@@ -27,5 +31,5 @@ TARG_EXEXTENSION = $(HOST_EXEXTENSION)
 BINDIR = /usr/local/bin
 INCDIR = /usr/local/include/asl
 MANDIR = /usr/local/man
-LIBDIR =
+LIBDIR = /usr/local/lib/asl
 DOCDIR = /usr/local/doc/asl

--- a/Makefile.def-samples/Makefile.def-emscripten
+++ b/Makefile.def-samples/Makefile.def-emscripten
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+# choose your compiler (must be ANSI-compliant!) and linker command, plus
+# any additionally needed flags
+
+OBJDIR =
+CC = emcc
+CFLAGS = -g -O3 -fomit-frame-pointer -Wall
+HOST_OBJEXTENSION = .o
+LD = $(CC)
+LDFLAGS =  -lnodefs.js -lnoderawfs.js
+HOST_EXEXTENSION =
+
+# no cross build
+
+TARG_OBJDIR = $(OBJDIR)
+TARG_CC = $(CC)
+TARG_CFLAGS = $(CFLAGS)
+TARG_OBJEXTENSION = $(HOST_OBJEXTENSION)
+TARG_LD = $(LD)
+TARG_LDFLAGS = $(LDFLAGS)
+TARG_EXEXTENSION = $(HOST_EXEXTENSION)
+
+# -------------------------------------------------------------------------
+# directories where binaries, includes, and manpages should go during
+# installation
+
+BINDIR = /usr/local/bin
+INCDIR = /usr/local/include/asl
+MANDIR = /usr/local/man
+LIBDIR =
+DOCDIR = /usr/local/doc/asl

--- a/code68k.c
+++ b/code68k.c
@@ -928,7 +928,7 @@ static void DecodeAbs(const tStrComp *pArg, ShortInt Size, tAdrResult *pResult)
 
     if (Size == 1)
     {
-      if (!IsShortAdr(HVal))
+      if (!mFirstPassUnknown(Flags) && !IsShortAdr(HVal))
       {
         WrError(ErrNum_NoShortAddr);
         pResult->Num = ModNone;

--- a/sysdefs.h
+++ b/sysdefs.h
@@ -1321,8 +1321,11 @@ typedef unsigned long long Card64;
 /*===========================================================================*/
 /* Misc... */
 
+/*---------------------------------------------------------------------------*/
+/* Emscripten */
+
 #ifdef __wasm__
-#define ARCHPRNAME "m68k"
+#define ARCHPRNAME "wasm"
 #define ARCHSYSNAME "wasm-emscripten"
 #define DEFSMADE
 #define OPENRDMODE "r"

--- a/sysdefs.h
+++ b/sysdefs.h
@@ -1321,6 +1321,28 @@ typedef unsigned long long Card64;
 /*===========================================================================*/
 /* Misc... */
 
+#ifdef __wasm__
+#define ARCHPRNAME "m68k"
+#define ARCHSYSNAME "wasm-emscripten"
+#define DEFSMADE
+#define OPENRDMODE "r"
+#define OPENWRMODE "w"
+#define OPENUPMODE "r+"
+#define IEEEFLOAT
+typedef signed char Integ8;
+typedef unsigned char Card8;
+typedef signed short Integ16;
+typedef unsigned short Card16;
+#define HAS16
+typedef signed int Integ32;
+#define PRIInteg32 "d"
+typedef unsigned int Card32;
+typedef signed long long Integ64;
+typedef unsigned long long Card64;
+#define HAS64
+#define NO_NLS
+#endif
+
 /*---------------------------------------------------------------------------*/
 /* Just for curiosity, it won't work without 16 bit int's... */
 


### PR DESCRIPTION
This bug could be triggered with the following code:

```asm
	CPU 68000
	phase $200000
	move.w	(dummy).w,d0
dummy = $100
```

What happens is that, when an undefined symbol is encountered in the first pass, [it is temporarily assigned the value of the program counter](https://github.com/flamewing/asl-releases/blob/34045459296251eec004b89db0be5b101040775c/asmpars.c#L2880).

In the above example, the `dummy` variable is undefined at the time that the line `move.w (dummy).w,d0` is encountered, causing it to be temporarily evaluated to `$200000`. Since `$200000` is not within short addressing range, the assembler throws an error, despite the actual value of the `dummy` variable being `$100`, which is within the range.

To fix this, I have made it so that the short addressing range check is not performed if the symbol is undefined. Note that this does not prevent the error from occurring when the true value of the variable is also out-of-range, as the range check is performed again when the line is re-evaluated in a later pass.

This fixes [the bug that I described](https://github.com/flamewing/asl-releases/issues/3#issuecomment-1112622215) in #3.