### PR TITLE
Correctly signal 'must be evaluable on first pass' error when using stale forward references

### DIFF
--- a/asmif.c
+++ b/asmif.c
@@ -68,9 +68,9 @@ static LongInt GetIfVal(tStrComp const* pCond) {
     LongInt      Tmp;
 
     Tmp = EvalStrIntExpressionWithFlags(pCond, Int32, &IfOK, &Flags);
-    if (mFirstPassUnknown(Flags) || !IfOK) {
+    if (mFirstPassUnknown(Flags) || mUsesForwards(Flags) || !IfOK) {
         Tmp = 1;
-        if (mFirstPassUnknown(Flags)) {
+        if (mFirstPassUnknown(Flags) || mUsesForwards(Flags)) {
             WrError(ErrNum_FirstPassCalc);
         }
     }


### PR DESCRIPTION
Closes #32.